### PR TITLE
feat: autocomplete in /debug commands

### DIFF
--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context as _};
 use poise::AutocompleteChoice;
+use tracing::{debug, instrument};
 
 use super::super::{drql, Context};
 
@@ -35,6 +36,7 @@ async fn scan(
     Ok(())
 }
 
+#[instrument(skip_all, fields(query = query))]
 async fn parse_one_autocomplete(_ctx: Context<'_>, query: &str) -> Vec<AutocompleteChoice<String>> {
     match drql::parser::parse_drql(query) {
         // When we encounter an error, we want to split it across multiple lines because Discord only
@@ -43,25 +45,29 @@ async fn parse_one_autocomplete(_ctx: Context<'_>, query: &str) -> Vec<Autocompl
         // 2. For a single line of the error message, we split on whitespace.
 
         // TODO: Move this to a function? It's sorta repetitive
-        Err(e) => format!("Encountered an error while parsing:\n{e:#}")
-            .split('\n')
-            .flat_map(|part| {
-                crate::util::wrap_string_vec(
-                    &part
-                        .split_whitespace()
-                        .map(std::string::ToString::to_string)
-                        .collect::<Vec<_>>(),
-                    " ",
-                    100,
-                )
-                .unwrap()
-            })
-            .map(|option| AutocompleteChoice {
-                name: option,
-                value: query.to_string(),
-            })
-            .collect::<Vec<_>>(),
+        Err(e) => {
+            debug!("Returning parse error response to autocomplete: {e:#}");
+            format!("Encountered an error while parsing:\n{e:#}")
+                .split('\n')
+                .flat_map(|part| {
+                    crate::util::wrap_string_vec(
+                        &part
+                            .split_whitespace()
+                            .map(std::string::ToString::to_string)
+                            .collect::<Vec<_>>(),
+                        " ",
+                        100,
+                    )
+                    .unwrap()
+                })
+                .map(|option| AutocompleteChoice {
+                    name: option,
+                    value: query.to_string(),
+                })
+                .collect::<Vec<_>>()
+        }
         Ok(_) => {
+            debug!("Returning \"Parsed successfully\" response to autocomplete");
             vec![AutocompleteChoice {
                 name: "Parsed successfully. Send command to view AST.".to_string(),
                 value: query.to_string(),
@@ -71,6 +77,7 @@ async fn parse_one_autocomplete(_ctx: Context<'_>, query: &str) -> Vec<Autocompl
 }
 
 /// Parse a single DRQL query
+#[instrument(skip_all, fields(query = query))]
 #[poise::command(slash_command)]
 async fn parse_one(
     ctx: Context<'_>,
@@ -88,6 +95,7 @@ async fn parse_one(
     Ok(())
 }
 
+#[instrument(skip_all, fields(query = query))]
 async fn reduce_autocomplete(_ctx: Context<'_>, query: &str) -> Vec<AutocompleteChoice<String>> {
     match drql::scanner::scan(query)
         .enumerate()
@@ -97,37 +105,47 @@ async fn reduce_autocomplete(_ctx: Context<'_>, query: &str) -> Vec<Autocomplete
         .collect::<Result<Vec<_>, _>>()
     {
         // The same whitespace printing is done here. First split on newlines, then split on spaces.
-        Err(e) => format!("Encountered an error while parsing:\n{e:#}")
-            .split('\n')
-            .flat_map(|part| {
-                crate::util::wrap_string_vec(
-                    &part
-                        .split_whitespace()
-                        .map(std::string::ToString::to_string)
-                        .collect::<Vec<_>>(),
-                    " ",
-                    100,
-                )
-                .unwrap()
-            })
-            .map(|option| AutocompleteChoice {
-                name: option,
-                value: query.to_string(),
-            })
-            .collect::<Vec<_>>(),
+        Err(e) => {
+            debug!("Returning parse error response to autocomplete: {e:#}");
+            format!("Encountered an error while parsing:\n{e:#}")
+                .split('\n')
+                .flat_map(|part| {
+                    crate::util::wrap_string_vec(
+                        &part
+                            .split_whitespace()
+                            .map(std::string::ToString::to_string)
+                            .collect::<Vec<_>>(),
+                        " ",
+                        100,
+                    )
+                    .unwrap()
+                })
+                .map(|option| AutocompleteChoice {
+                    name: option,
+                    value: query.to_string(),
+                })
+                .collect::<Vec<_>>()
+        }
 
-        Ok(exprs) if exprs.is_empty() => vec![AutocompleteChoice {
-            name: "No chunks found.".to_string(),
-            value: query.to_string(),
-        }],
-        Ok(_) => vec![AutocompleteChoice {
-            name: "Parsed successfully. Send command to view reduced AST.".to_string(),
-            value: query.to_string(),
-        }],
+        Ok(exprs) if exprs.is_empty() => {
+            debug!("Returning \"No chunks found\" response to autocomplete");
+            vec![AutocompleteChoice {
+                name: "No chunks found.".to_string(),
+                value: query.to_string(),
+            }]
+        }
+        Ok(_) => {
+            debug!("Returning \"Parsed successfully\" response to autocomplete");
+            vec![AutocompleteChoice {
+                name: "Parsed successfully. Send command to view reduced AST.".to_string(),
+                value: query.to_string(),
+            }]
+        }
     }
 }
 
 /// Scan the input, parse each query, and finally reduce into one tree
+#[instrument(skip_all, fields(msg = msg))]
 #[poise::command(slash_command)]
 async fn reduce(
     ctx: Context<'_>,


### PR DESCRIPTION
This is **part** of completing #30. More is needed. We'd like to have a full on experience built around it, suggesting role/user names and other things not just related to the parser, like showing name conflicts (two roles match your query) and such.